### PR TITLE
feat: add support for conditional installation of protoc-gen-swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,16 @@
 [protoc-gen-grpc-swift](https://github.com/grpc/grpc-swift/blob/main/docs/plugin.md) plugin for the [asdf version manager](https://asdf-vm.com).
 </div>
 
-Please note that in addition to `protoc-gen-grpc-swift` protobuf compiler plugin, `protoc-gen-swift` plugin will be installed as well.
-At the moment, [swift-protobuf](https://github.com/apple/swift-protobuf) repository does not provide prebuilt binaries for its `protoc` plugin while [grpc-swift](https://github.com/grpc/grpc-swift) provides both.
+> [!NOTE]
+> In addition to `protoc-gen-grpc-swift` protobuf compiler plugin, `protoc-gen-swift` plugin will be installed as well.
+>
+> At the moment, [swift-protobuf](https://github.com/apple/swift-protobuf) repository does not provide prebuilt binaries for its `protoc` plugin while [grpc-swift](https://github.com/grpc/grpc-swift) provides both.
+>
+> If you are using [mise](https://www.example.com) to manage plugins and would like to skip installation of `protoc-gen-swift`, you can pass the `skip_protoc_gen_swift_install` environment variable like so:
+>
+> `protoc-gen-grpc-swift = { version = '1.23.0', skip_protoc_gen_swift_install = 'true' }`
+>
+> This will be passed to the plugin scripts as `MISE_TOOL_OPTS__SKIP_PROTOC_GEN_SWIFT_INSTALL=true`
 
 # Contents
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 >
 > At the moment, [swift-protobuf](https://github.com/apple/swift-protobuf) repository does not provide prebuilt binaries for its `protoc` plugin while [grpc-swift](https://github.com/grpc/grpc-swift) provides both.
 >
-> If you are using [mise](https://www.example.com) to manage plugins and would like to skip installation of `protoc-gen-swift`, you can pass the `skip_protoc_gen_swift_install` environment variable like so:
+> If you are using [mise](https://mise.jdx.dev) to manage plugins and would like to skip installation of `protoc-gen-swift`, you can pass the `skip_protoc_gen_swift_install` environment variable like so:
 >
 > `protoc-gen-grpc-swift = { version = '1.23.0', skip_protoc_gen_swift_install = 'true' }`
 >

--- a/contributing.md
+++ b/contributing.md
@@ -5,8 +5,7 @@ Testing Locally:
 ```shell
 asdf plugin test <plugin-name> <plugin-url> [--asdf-tool-version <version>] [--asdf-plugin-gitref <git-ref>] [test-command*]
 
-# TODO: adapt this
-asdf plugin test protoc-gen-grpc-swift https://github.com/sergiymomot/asdf-protoc-gen-grpc-swift.git "protoc-gen-swift --version <TOOL CHECK><TOOL CHECK> protoc-gen-grpc-swift --version"
+asdf plugin test protoc-gen-grpc-swift https://github.com/sergiymomot/asdf-protoc-gen-grpc-swift.git "protoc-gen-grpc-swift --version && protoc-gen-swift --version"
 ```
 
 Tests are automatically run in GitHub Actions on push and PR.


### PR DESCRIPTION
This change adds support for conditional installation of the `protoc-gen-swift` binary using the `MISE_TOOL_OPTS__SKIP_PROTOC_GEN_SWIFT_INSTALL` environment variable, in case there is a need to use a different version from the one bundled with [grpc-swift](https://github.com/grpc/grpc-swift).

A plugin that only installs `protoc-gen-swift` by compiling from source can be found [here](https://github.com/currentjeff/asdf-protoc-gen-swift)